### PR TITLE
Feat: added dockerfile for deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install
+
+# Build and export static site
+COPY . .
+RUN yarn build
+# Expose default Next.js port
+EXPOSE 3000
+
+# Run Next.js server
+CMD ["yarn", "start"]


### PR DESCRIPTION
# Why?

Deployment in Coolify requires application to be containerized. PR adds missing dockerfile to build and deploy application.